### PR TITLE
Potential fix for code scanning alert no. 4: Replacement of a substring with itself

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -408,7 +408,7 @@ function handlePositionUpdate(position) {
         // Update headwind/crosswind labels
         if (!settings || settings["imperial-units"]) {
             document.getElementById('headwind-label').innerText =
-                document.getElementById('headwind-label').innerText.replace("(MPH)", "(MPH)");
+                document.getElementById('headwind-label').innerText;
             document.querySelector('.stat-box:nth-child(4) .stat-label').innerText =
                 document.querySelector('.stat-box:nth-child(4) .stat-label').innerText.replace("(MPH)", "(MPH)");
         } else {


### PR DESCRIPTION
Potential fix for [https://github.com/jonbirge/tesla-cloud/security/code-scanning/4](https://github.com/jonbirge/tesla-cloud/security/code-scanning/4)

To fix the issue, we will remove the redundant replacement operation on line 411. Since the substring `"(MPH)"` is already correct and does not need to be replaced with itself, this line can be safely deleted. This will simplify the code and eliminate the unnecessary operation without affecting the functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
