### PR TITLE
Fix JSON validation in rest_db

### DIFF
--- a/rest_db.php
+++ b/rest_db.php
@@ -197,8 +197,9 @@ if ($method === 'POST') {
     $path = ltrim($uri, '/');
     $json = file_get_contents('php://input');
     
-    // Validate JSON input
-    if (!json_decode($json)) {
+    // Validate JSON input without altering payload
+    json_decode($json);
+    if (json_last_error() !== JSON_ERROR_NONE) {
         http_response_code(400);
         echo json_encode(['error' => 'Invalid JSON input']);
         exit;


### PR DESCRIPTION
## Summary
- handle JSON validation properly in rest_db.php

## Testing
- `./test/dotenv.sh`
- `./test/restdb.sh` *(fails: 404 File not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1957f324832b8acb0b2503f7ea5b