### PR TITLE
Improve mobile layout and add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "tesla-cloud",
+    "image": "mcr.microsoft.com/devcontainers/php:8.2",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/devcontainers/features/git-lfs:1": {}
+    },
+    "forwardPorts": [80],
+    "postCreateCommand": "composer install"
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -1262,16 +1262,19 @@ body.dark-mode .option-button:hover:not(.active) {
     /* Layout adjustment */
     .frame-container {
         flex-direction: column;
+        position: static; /* allow page scrolling */
+        height: auto;
+        overflow: visible;
     }
     
     /* Convert left menu to horizontal top menu */
     .left-frame {
         width: 100%;
         height: auto;
-        max-height: 90px;
+        max-height: none; /* allow multiple rows */
         padding: 5px;
         overflow-y: hidden;
-        overflow-x: auto;
+        overflow-x: visible;
         -webkit-overflow-scrolling: touch;
         scrollbar-width: none; /* Hide scrollbar for Firefox */
     }
@@ -1283,10 +1286,10 @@ body.dark-mode .option-button:hover:not(.active) {
     /* Convert section buttons to horizontal layout */
     .section-buttons {
         flex-direction: row;
+        flex-wrap: wrap; /* show all buttons */
         min-width: min-content;
-        width: auto;
-        /* height: 80px; */
-        overflow-x: auto;
+        width: 100%;
+        overflow-x: visible;
     }
     
     .section-buttons h1 {
@@ -1306,10 +1309,16 @@ body.dark-mode .option-button:hover:not(.active) {
         height: 16px;
         margin-right: 8px;
     }
+
+    /* Scroll indicators span full width on mobile */
+    .scroll-indicator {
+        left: 0;
+        right: 0;
+    }
     
     /* Right frame takes remaining space */
     .right-frame {
-        height: calc(100vh - 90px);
+        height: calc(100vh - 120px); /* account for two rows of buttons */
         padding: 10px 15px;
     }
     


### PR DESCRIPTION
## Summary
- update mobile styles so section buttons wrap and gradients fit screen width
- allow page scrolling on mobile by adjusting container layout
- allocate space for two rows of buttons
- add devcontainer configuration for Codespaces

## Testing
- `bash test/dotenv.sh`
- `bash test/restdb.sh` *(fails: DELETE key failed with status 404)*

------
https://chatgpt.com/codex/tasks/task_e_688d330cb95c832b9b7b5d409aafffcf