### PR TITLE
Improve news fetch error handling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
     "features": {
         "ghcr.io/devcontainers/features/php:1": {
             "version": "8.2"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "20"
         }
     },
     "forwardPorts": [8000],

--- a/js/news.js
+++ b/js/news.js
@@ -335,6 +335,11 @@ export async function updateNews(clear = false) {
         // Clear the timeout since request completed
         clearTimeout(timeoutId);
 
+        // Throw an error for non-2xx responses to provide better context to the user
+        if (!response.ok) {
+            throw new Error(`Server returned ${response.status} ${response.statusText}`);
+        }
+
         let loadedItems = await response.json();
         console.log('...Done! Count: ', loadedItems.length);
         
@@ -410,19 +415,24 @@ export async function updateNews(clear = false) {
             newsContainer.innerHTML = '<p><em>No unread headlines available</em></p>';
         }
     } catch (error) {
+        let userMessage;
+
         if (error.name === 'AbortError') {
-            console.error('News fetch timed out after 2 seconds');
+            console.error('News fetch timed out', error);
+            userMessage = 'The news request timed out. Please check your connection and try reloading.';
         } else {
             console.error('Error fetching news:', error);
+            const detail = error && error.message ? ` (${error.message})` : '';
+            userMessage = `Error loading headlines${detail}. Please try reloading.`;
         }
-        
+
         // Make sure to hide the spinner even in case of an error
         document.getElementById('news-loading').style.display = 'none';
         document.getElementById('newsHeadlines').style.display = 'block';
-        
+
         const newsContainer = document.getElementById('newsHeadlines');
         if (newsContainer) {
-            newsContainer.innerHTML = '<p><em>Error loading headlines</em></p>';
+            newsContainer.innerHTML = `<p><em>${userMessage}</em></p>`;
         }
     }
 

--- a/js/news.js
+++ b/js/news.js
@@ -432,7 +432,13 @@ export async function updateNews(clear = false) {
 
         const newsContainer = document.getElementById('newsHeadlines');
         if (newsContainer) {
-            newsContainer.innerHTML = `<p><em>${userMessage}</em></p>`;
+            // Clear the container and safely insert the message as text
+            newsContainer.innerHTML = '';
+            const p = document.createElement('p');
+            const em = document.createElement('em');
+            em.textContent = userMessage;
+            p.appendChild(em);
+            newsContainer.appendChild(p);
         }
     }
 


### PR DESCRIPTION
## Summary
- Show detailed error messages in `news.js` when news download fails, including HTTP status or timeout hints, and prompt users to reload
- Add Node.js support to the dev container for easier Codespaces development

## Testing
- `bash dotenv.sh` (from `test` directory)
- `bash restdb.sh` (failed: DELETE key failed with status 404)


------
https://chatgpt.com/codex/tasks/task_e_689ac3b08e58832bb193d7417df00128