### PR TITLE
Expand weather panel to seven-day forecast

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
     "features": {
         "ghcr.io/devcontainers/features/php:1": {
             "version": "8.2"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "20"
         }
     },
     "forwardPorts": [8000],

--- a/css/wx.css
+++ b/css/wx.css
@@ -92,7 +92,7 @@ body.dark-mode {
 /* Weather Forecast */
 .forecast-container {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
     gap: 15px;
     margin: 1px 0;
     max-width: 1100px;
@@ -103,8 +103,8 @@ body.dark-mode {
     padding: 15px;
     text-align: center;
     position: relative;
-    min-width: 120px;
-    max-width: 180px;
+    min-width: 85px;
+    max-width: 130px;
     overflow: hidden;
 }
 
@@ -438,8 +438,8 @@ body.dark-mode .notification-icon img {
     
     .forecast-day {
         padding: 10px;
-        min-width: 100px;
-        max-width: 140px;
+        min-width: 70px;
+        max-width: 100px;
     }
     
     .forecast-date {

--- a/css/wx.css
+++ b/css/wx.css
@@ -202,7 +202,7 @@ body.dark-mode .forecast-day.rain img.forecast-icon {
 }
 
 .forecast-date {
-    font-size: 12pt;
+    font-size: 10pt;
     font-weight: 650;
     margin-bottom: 8px;
     text-transform: uppercase;
@@ -221,7 +221,7 @@ body.dark-mode .forecast-date {
 }
 
 .forecast-temp {
-    font-size: 15pt;
+    font-size: 14pt;
     font-weight: 750;
     margin: 8px 0;
     color: var(--button-text);
@@ -234,9 +234,9 @@ body.dark-mode .forecast-temp {
 
 .forecast-desc {
     font-family: "Inter", sans-serif;
-    font-size: 14pt;
+    font-size: 13pt;
     font-style: italic;
-    font-weight: 600;
+    font-weight: 500;
     color: var(--button-text);
     text-shadow: 0 0 8px rgba(255, 255, 255, 0.8), 0 0 16px rgba(255, 255, 255, 0.6);
 }

--- a/index.html
+++ b/index.html
@@ -192,6 +192,20 @@
                     <div class="forecast-desc"></div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
+                <div class="forecast-day">
+                    <div class="forecast-date"></div>
+                    <img class="forecast-icon" src="">
+                    <div class="forecast-temp"></div>
+                    <div class="forecast-desc"></div>
+                    <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
+                </div>
+                <div class="forecast-day">
+                    <div class="forecast-date"></div>
+                    <img class="forecast-icon" src="">
+                    <div class="forecast-temp"></div>
+                    <div class="forecast-desc"></div>
+                    <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
+                </div>
             </div>
             <!-- Minutely precipitation forecast graph elements -->
             <div id="minutely-precip-container" class="minutely-precip" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/styles.css?0522">
-    <link rel="stylesheet" href="css/wx.css?0522">
-    <link rel="stylesheet" href="css/timeline.css?0522">
+    <link rel="stylesheet" href="css/styles.css?0808">
+    <link rel="stylesheet" href="css/wx.css?0808">
+    <link rel="stylesheet" href="css/timeline.css?0808">
 </head>
 
 <body>
@@ -795,7 +795,7 @@
 
     <!-- Load JavaScript -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="js/app.js?0522" type="module"></script>
+    <script src="js/app.js?0808" type="module"></script>
 </body>
 
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,7 @@
 import { srcUpdate, testMode, updateTimeZone, GEONAMES_USERNAME } from './common.js';
 import { PositionSimulator } from './location.js';
 import { attemptLogin, leaveSettings, settings, isDriving, setDrivingState, enableLiveNewsUpdates } from './settings.js';
-import { fetchPremiumWeatherData, fetchCityData, SAT_URLS, forecastDataPrem, currentRainAlert } from './wx.js';
+import { fetchPremiumWeatherData, fetchCityData, SAT_URLS, forecastDataPrem, currentRainAlert } from './wx.js?8080';
 import { updateNetworkInfo, updatePingChart, startPingTest } from './net.js';
 import { setupNewsObserver, startNewsTimeUpdates, initializeNewsStorage } from './news.js';
 import { startStockUpdates, stopStockUpdates } from './stock.js';

--- a/js/wx.js
+++ b/js/wx.js
@@ -143,7 +143,7 @@ export async function fetchCityData(lat, long) {
 export function updatePremiumWeatherDisplay() {
     if (!forecastDataPrem) return;
 
-    // Extract daily summary (first 5 days)
+    // Extract daily summary (first 7 days)
     const dailyData = extractPremiumDailyForecast(forecastDataPrem.daily || []);
     const forecastDays = document.querySelectorAll('#prem-forecast-container .forecast-day');
 
@@ -674,7 +674,7 @@ function updateAQI(lat, lon) {
 // Helper: Extract 5 daily summaries from OpenWeather 3.0 API
 function extractPremiumDailyForecast(dailyList) {
     // dailyList is already daily summaries (up to 8 days)
-    return dailyList.slice(0, 5);
+    return dailyList.slice(0, 7);
 }
 
 // Helper: Format temperature based on user settings


### PR DESCRIPTION
## Summary
- Display a 7-day weather forecast by adding two more panels and fetching seven days of data
- Narrow daily forecast tiles and adjust grid to fit seven panels
- Include Node.js in devcontainer for easier Codespaces development

## Testing
- `node --check js/wx.js`
- `npx --yes htmlhint index.html` *(fails: The attribute [ src ] of the tag [ img ] must have a value, etc.)*
- `npx --yes stylelint css/wx.css` *(fails: No configuration provided for css/wx.css)*

------
https://chatgpt.com/codex/tasks/task_e_689b6c80dfa0832b942ef1dca9b83f7e