### PR TITLE
Add RainMap option to dashboard map

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,9 @@
             <div class="teslawaze-container">
                 <div id="in-map-toggle" class="settings-toggle-item option-switch-container" data-setting="map-choice">
                     <div class="option-switch">
-                        <button class="option-button active" data-value="waze" onclick="toggleOptionSetting(this)">Waze</button>
-                        <button class="option-button" data-value="abrp" onclick="toggleOptionSetting(this)">ABRP</button>
+                        <button class="option-button active" data-value="waze" onclick="toggleOptionSetting(this)">TeslaWaze</button>
+                        <button class="option-button" data-value="abrp" onclick="toggleOptionSetting(this)">ABP</button>
+                        <button class="option-button" data-value="rainmap" onclick="toggleOptionSetting(this)">RainMap</button>
                     </div>
                 </div>
                 <iframe id="teslawaze" src="" allow="geolocation" loading="lazy"></iframe>
@@ -514,7 +515,9 @@
                         <button class="option-button active" data-value="waze"
                             onclick="toggleOptionSetting(this)">TeslaWaze</button>
                         <button class="option-button" data-value="abrp"
-                            onclick="toggleOptionSetting(this)">ABRP</button>
+                            onclick="toggleOptionSetting(this)">ABP</button>
+                        <button class="option-button" data-value="rainmap"
+                            onclick="toggleOptionSetting(this)">RainMap</button>
                     </div>
                 </div>
 

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
             <div class="teslawaze-container">
                 <div id="in-map-toggle" class="settings-toggle-item option-switch-container" data-setting="map-choice">
                     <div class="option-switch">
-                        <button class="option-button active" data-value="waze" onclick="toggleOptionSetting(this)">TeslaWaze</button>
+                        <button class="option-button active" data-value="waze" onclick="toggleOptionSetting(this)">Waze</button>
                         <button class="option-button" data-value="abrp" onclick="toggleOptionSetting(this)">ABP</button>
                         <button class="option-button" data-value="rainmap" onclick="toggleOptionSetting(this)">RainMap</button>
                     </div>
@@ -513,7 +513,7 @@
                     <label>Dashboard Map</label>
                     <div class="option-switch">
                         <button class="option-button active" data-value="waze"
-                            onclick="toggleOptionSetting(this)">TeslaWaze</button>
+                            onclick="toggleOptionSetting(this)">Waze</button>
                         <button class="option-button" data-value="abrp"
                             onclick="toggleOptionSetting(this)">ABP</button>
                         <button class="option-button" data-value="rainmap"

--- a/js/app.js
+++ b/js/app.js
@@ -716,6 +716,8 @@ window.updateMapFrame = function () {
     let testModeMsg = teslaWazeContainer.querySelector('.test-mode-message');
     if (settings["map-choice"] === 'waze') {
         srcUpdate("teslawaze", "https://teslawaze.azurewebsites.net/");
+    } else if (settings["map-choice"] === 'rainmap') {
+        srcUpdate("teslawaze", "https://car.rainviewer.com/");
     } else {
         srcUpdate("teslawaze", "https://abetterrouteplanner.com/");
     }


### PR DESCRIPTION
## Summary
- add RainMap as a dashboard map option alongside TeslaWaze and ABP
- support RainMap in JavaScript map loading logic

## Testing
- `bash test/dotenv.sh`
- `bash test/restdb.sh` (fails: File not found.)

------
https://chatgpt.com/codex/tasks/task_e_68a52b930ae8832b827eec4042aa9013