### PR TITLE
Fix GPS icon visibility and hide controls on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -170,6 +170,9 @@ hr {
     .announcement p .note-text {
         display: block;
     }
+    .control-container {
+        display: none;
+    }
 }
 
 /* Layout */
@@ -533,6 +536,23 @@ body.dark-mode .network-icon {
 
 .gps-status {
     color: var(--status-unavailable);
+}
+
+.gps-status svg {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+    display: block;
+}
+
+.gps-status .gps-outer {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+}
+
+.gps-status .gps-inner {
+    fill: currentColor;
 }
 
 /* Rain Status Indicator */

--- a/index.html
+++ b/index.html
@@ -708,11 +708,9 @@
             <span id="rain-timing-text"></span>
         </div>
         <div id="gps-status" class="status-indicator gps-status unavailable" title="GPS Status">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-                <!-- Outer circle -->
-                <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="2"/>
-                <!-- Inner circle -->
-                <circle cx="12" cy="12" r="3" fill="currentColor"/>
+            <svg class="gps-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+                <circle class="gps-outer" cx="12" cy="12" r="8"></circle>
+                <circle class="gps-inner" cx="12" cy="12" r="3"></circle>
             </svg>
         </div>
         <div id="stock-indicators" style="display: flex;">


### PR DESCRIPTION
## Summary
- ensure GPS status SVG is visible by adding explicit class-based styling
- hide control container on small screens

## Testing
- `bash dotenv.sh`
- `bash restdb.sh` *(fails: File not found from remote API)*

------
https://chatgpt.com/codex/tasks/task_e_68b5196c754c832b92cad1789237f191