### PR TITLE
Simplify login flow

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -739,26 +739,6 @@ body.dark-mode .spinner {
     margin: 20px 0;
 }
 
-/* Login Styles */
-.login-button {
-    color: var(--button-text);
-    background-color: var(--button-bg);
-    border-radius: var(--button-radius);
-    font-size: 16pt;
-    font-weight: 600;
-    padding: 16px 20px;
-    border: none;
-    cursor: pointer;
-    text-align: center;
-    margin-top: 15px;
-    width: 100%;
-    transition: background-color 0.3s;
-}
-
-.login-button:hover {
-    background-color: var(--active-section-bg);
-}
-
 /* Modal Login Dialog */
 .modal {
     display: none;

--- a/index.html
+++ b/index.html
@@ -75,7 +75,6 @@
                 About
             </button>
         </div> <!-- End of section buttons -->
-        <button id="login-button" class="login-button" onclick="showLoginModal()">Login</button>
     </div> <!-- End of left frame -->
     
     <!-- Section content -->
@@ -456,11 +455,9 @@
             <ul>
                 <li>Bookmark this page using the star in the browser menu.</li>
                 <li>Make the browser easily available by dragging it to the left-hand side of the dock at the bottom of the screen.</li>
-                <li>Settings are saved by default, but you can logout (under Settings) to disable this.</li>
-                <li>You can also create a user ID that will allow settings to be saved across multiple browsers:</li>
+                <li>Settings are saved locally by default. You can create a user ID that will allow settings to be saved across multiple browsers:</li>
                 <ol>
-                    <li>Ensure you're logged out of the default user account in Settings.</li>
-                    <li>Select the 'login' button on the main page and choose an ID with 9 or more characters.</li>
+                    <li>In Settings, select "Login" and choose an ID with 9 or more characters.</li>
                     <li>The user ID can be anything you can remember, like your phone number; it is encrypted before being sent to our servers.</li>
                 </ol>
             </ul>
@@ -476,7 +473,7 @@
         </div>
         
         <div id="settings" class="section">
-            <button id="logout-button" class="logout-button hidden" onclick="handleLogout()">Logout</button>
+            <button id="logout-button" class="logout-button" onclick="handleLogout()">Login</button>
         
             <h2>General Settings</h2>
             <div class="settings-controls">

--- a/js/settings.js
+++ b/js/settings.js
@@ -402,21 +402,12 @@ async function autoCreateUser() {
 
 // Update login/logout button visibility based on state
 function updateLoginState() {
-    const loginButton = document.getElementById('login-button');
     const logoutButton = document.getElementById('logout-button');
 
-    if (isLoggedIn) {
-        loginButton.classList.add('hidden');
-        logoutButton.classList.remove('hidden');
-        if (currentUser) {
-            logoutButton.textContent = `Logout ${currentUser}`;
-        } else {
-            logoutButton.textContent = 'Logout default user';
-        }
+    if (currentUser) {
+        logoutButton.textContent = `Logout ${currentUser}`;
     } else {
-        loginButton.classList.remove('hidden');
-        logoutButton.classList.add('hidden');
-        logoutButton.textContent = 'Logout';
+        logoutButton.textContent = 'Login';
     }
 }
 
@@ -892,26 +883,24 @@ window.closeLoginModal = function () {
     document.getElementById('login-modal').style.display = 'none';
 }
 
-// Function to handle logout
-window.handleLogout = function () {
-    isLoggedIn = false;
-    currentUser = null;
-    hashedUser = null;
-    
-    // Update UI
-    updateLoginState();
-    
-    // Hide settings section
-    document.getElementById('settings-section').classList.add('hidden');
-    
-    // If currently in settings section, redirect to default section
-    const settingsSection = document.getElementById('settings');
-    if (settingsSection.style.display === 'block') {
-        showSection('news');
+// Function to handle login/logout button
+window.handleLogout = async function () {
+    if (currentUser) {
+        // Logging out of a named user; revert to auto-generated account
+        deleteCookie('userid');
+        currentUser = null;
+        hashedUser = null;
+
+        const autoUser = getCookie('auto-userid');
+        if (autoUser && await validateAutoUserId(autoUser)) {
+            await fetchSettings();
+            await initializeNewsStorage();
+            updateNews(true);
+        }
+    } else {
+        // Default user active, show login dialog
+        showLoginModal();
     }
-    
-    // Ensure we won't auto login to a named user
-    deleteCookie('userid');
 }
 
 // Function to handle login from dialog


### PR DESCRIPTION
## Summary
- Replace default logout button with single login/logout control that toggles between anonymous and named users
- Drop standalone left-frame login button and adjust Quick Tips documentation
- Reset user session to auto-generated ID when logging out from a named account

## Testing
- `./test/dotenv.sh`
- `./test/restdb.sh` *(fails: Root level key retrieval failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0527254832b99f5b283cb87acef